### PR TITLE
Tox config fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ description = Run integration tests
 deps =
     pytest
     juju
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
This PR introduces the following changes on `tox.ini`:

- Fixed pytest-operator dependency (fixes: `Could not find a version that satisfies the requirement pytest-operator.git (from versions: none)`).
- Fixed unit test source path on coverage command (fixes: `Can't find '__main__' module in 'tests'`).

Reference CI run: https://github.com/canonical/operator-template/actions/runs/1466403426