### PR TITLE
codespell everything

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,11 @@ deps =
     isort
     codespell
 commands =
-    codespell {toxinidir}/*.yaml {toxinidir}/*.ini {toxinidir}/*.md \
-      {toxinidir}/*.toml {toxinidir}/*.txt {toxinidir}/.github
+    # uncomment the following line if this charm owns a lib
+    # codespell {[vars]lib_path}
+    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
+      --skip {toxinidir}/.mypy_cache
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}


### PR DESCRIPTION
Fixes #7

* check the entire source folder
* skip ephemerals
* scan `lib/` separately (no need to spell check libs not owned by this charm)