### PR TITLE
Update pytest options in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ show_missing = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-log_cli_level = "INFO"
+log-cli-level = "INFO"
 
 # Formatting tools configuration
 [tool.black]


### PR DESCRIPTION
I **think** these should be hyphens.  I find examples using hyphens, and cannot find examples using underscores.