### PR TITLE
deduplicate CI runs on updates to PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Tests
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,7 @@ class OperatorTemplateCharm(CharmBase):
                 }
             },
         }
-        # Add intial Pebble config layer using the Pebble API
+        # Add initial Pebble config layer using the Pebble API
         container.add_layer("httpbin", pebble_layer, combine=True)
         # Autostart any services that were defined with startup: enabled
         container.autostart()


### PR DESCRIPTION
Prevents CI from running twice when pushing an update to an open PR.  

With `on: [push, pull_request]`, pushing an update to some branch a branch with an open PR triggers CI twice (once for the push, once for the update to the PR).  This avoids that scenario, while maintaining a final CI run whenever something is merged into main.  Note that an (acceptable?) compromise here is that if merging a PR between branches, there will not be a final CI run

...also, I'm 99% this is all true, but none of the CI runs on this particular repo are duplicated.  I **think** this is because they're created from forks (and PRs from within this repo would have duplicate CI runs), but I'd love to be proven wrong.  We have duplicate CI runs in some of our Kubeflow repos and this fix sorted it out