### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,67 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ['Type: Bug', 'Status: Triage']
+assignees: ''
+---
+
+<!--
+  Before submitting your issue, please make sure you're using the latest version of the charm.
+  If not, switch to this image prior to posting your report to make sure it's not already solved.
+-->
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!--
+Steps to reproduce the behavior:
+1. `juju deploy ...`
+2. `juju relate ...`
+3. `juju status --relations`
+4. See error
+-->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
+
+**Environment**
+<!-- 
+
+We want to know:
+- Track and channel you deployed the charm from (ie. `latest/edge` or similar)
+ - Version of any applicable components, like:
+	 - Juju
+	 - Controller
+	 - Lxd
+	 - Microk8s
+	 - Multipass
+ - Is the issue surfacing for cross-model relations, same model or both?
+ - Are you running juju locally, in multipass, or on some other platform?
+
+-->
+
+<details>
+<!--
+  Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`.
+  Additional details available in the juju docs at https://juju.is/docs/olm/juju-logs
+-->
+<summary><b>Logs</b></summary>
+
+
+```
+
+```
+
+</details>
+
+**Additional context**
+<!--
+  Add any other context about the problem here.
+-->


### PR DESCRIPTION
Here's an issue template I put together that we've started using in the observability repositories. The idea is that it would decrease the number of issues lacking vital information created in a charm repo.